### PR TITLE
Add check for existence of config folder

### DIFF
--- a/pacmanfile
+++ b/pacmanfile
@@ -29,6 +29,11 @@ fi
 config_dir=${XDG_CONFIG_HOME:-$HOME/.config}
 pacmanfile_dir="${config_dir}/pacmanfile"
 
+# Create config folder if not present
+if [ ! -d $pacmanfile_dir ]; then
+	mkdir -p $pacmanfile_dir
+fi
+
 # Parse arguments
 operation=help
 option_confirm='--confirm'

--- a/pacmanfile
+++ b/pacmanfile
@@ -29,11 +29,6 @@ fi
 config_dir=${XDG_CONFIG_HOME:-$HOME/.config}
 pacmanfile_dir="${config_dir}/pacmanfile"
 
-# Create config folder if not present
-if [ ! -d $pacmanfile_dir ]; then
-	mkdir -p $pacmanfile_dir
-fi
-
 # Parse arguments
 operation=help
 option_confirm='--confirm'
@@ -64,6 +59,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 function dump {
+  
+  # Create config folder if not present
+  if [ ! -d $pacmanfile_dir ]; then
+  	mkdir -p $pacmanfile_dir
+  fi
   dump_file="${pacmanfile_dir}/pacmanfile-dumped.txt"
   installed_packages=$($package_manager --query --explicit --quiet | sort --unique)
 


### PR DESCRIPTION
If pacmanfile is installed for the first time, the config folder does not yet exist. A dump will consequently fail, since the folder to write can't be found.

This simple check routine should mitigate the error.