### PR TITLE
Allow single-character package names

### DIFF
--- a/pacmanfile
+++ b/pacmanfile
@@ -73,7 +73,7 @@ function dump {
 }
 
 function sync {
-  pacmanfile_packages=$(sort --unique "${pacmanfile_dir}"/pacmanfile*.txt | grep -E '^[^#].+')
+  pacmanfile_packages=$(sort --unique "${pacmanfile_dir}"/pacmanfile*.txt | grep -E '^[^#].*')
   installed_packages=$($package_manager --query --explicit --quiet | sort --unique)
 
   to_install=$(diff --new-line-format="" --unchanged-line-format="" <(echo "$pacmanfile_packages") <(echo "$installed_packages"))


### PR DESCRIPTION
I was trying out pacmanfile and it wanted to remove the `r` package when syncing -- turns out that the regex was assuming that package names are at least two characters long. An easy fix :) 

Useful little script, thanks!